### PR TITLE
Run "Get CPU architecture" in check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
   command: getconf LONG_BIT
   register: cpu_arch
   changed_when: False
+  check_mode: no
 
 - name: Change URL destination for 32bit arch
   set_fact:


### PR DESCRIPTION
Without this, "Change URL destination for 32bit arch" fails in check mode as "Get CPU architecture" is skipped